### PR TITLE
Add option to read message from path

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,15 @@ with:
     This is message from push.
 ```
 
+### Read comment from a file
+
+```yaml
+uses: marocchino/sticky-pull-request-comment@v1
+with:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  path: path-to-comment-contents.txt
+```
+
 ## Development
 
 Install the dependencies

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,10 @@ inputs:
     required: false
   message:
     description: "comment message"
-    required: true
+    required: false
+  path:
+    description: "path to file containing comment message"
+    required: false
   number:
     description: "pull request number for push event"
     required: false

--- a/lib/main.js
+++ b/lib/main.js
@@ -19,6 +19,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(require("@actions/core"));
 const github_1 = require("@actions/github");
 const comment_1 = require("./comment");
+const fs_1 = require("fs");
 function run() {
     var _a, _b;
     return __awaiter(this, void 0, void 0, function* () {
@@ -30,12 +31,23 @@ function run() {
         }
         try {
             const repo = github_1.context.repo;
-            const body = core.getInput("message", { required: true });
+            const message = core.getInput("message", { required: false });
+            const path = core.getInput("path", { required: false });
             const header = core.getInput("header", { required: false }) || "";
             const append = core.getInput("append", { required: false }) || false;
             const githubToken = core.getInput("GITHUB_TOKEN", { required: true });
             const octokit = new github_1.GitHub(githubToken);
             const previous = yield comment_1.findPreviousComment(octokit, repo, number, header);
+            if (!message && !path) {
+                throw { message: 'Either message or path input is required' };
+            }
+            let body;
+            if (path) {
+                body = fs_1.readFileSync(path);
+            }
+            else {
+                body = message;
+            }
             if (previous) {
                 if (append) {
                     yield comment_1.updateComment(octokit, repo, previous.id, body, header, previous.body);


### PR DESCRIPTION
Hello, thanks for creating this, last night I was thinking “this should be a shareable action” 🤓

I have use for posting a comment from a file rather than constructing it in the workflow configuration, like you mention in #53. This branch accomplishes that. It was very little work, let me know if you have any changes you’d like to see.

You can see [here](https://github.com/hashicorp/nomad/actions/runs/102664362) an example of it failing when neither `message` nor `path` are specified. [Here](https://github.com/hashicorp/nomad/pull/7929#issuecomment-627405893) is an example comment that has been posted from a file.