### PR TITLE
Add option to delete the previous comment and create a new one instead of editing

### DIFF
--- a/__tests__/comment.test.ts
+++ b/__tests__/comment.test.ts
@@ -1,7 +1,8 @@
 import {
   findPreviousComment,
   createComment,
-  updateComment
+  updateComment,
+  deleteComment
 } from "../src/comment";
 const repo = {};
 it("findPreviousComment", async () => {
@@ -95,5 +96,32 @@ it("createComment", async () => {
   expect(octokit.issues.createComment).toBeCalledWith({
     issue_number: 456,
     body: "<!-- Sticky Pull Request CommentTypeA -->\nhello there"
+  });
+});
+
+it("removeComment", async () => {
+  const octokit = {
+    issues: {
+      deleteComment: jest.fn(() => Promise.resolve())
+    }
+  };
+  expect(
+    await deleteComment(octokit, repo, 456)
+  ).toBeUndefined();
+  expect(octokit.issues.deleteComment).toBeCalledWith({
+    comment_id: 456
+  });
+  expect(
+    await deleteComment(octokit, repo, 456)
+  ).toBeUndefined();
+  expect(octokit.issues.deleteComment).toBeCalledWith({
+    comment_id: 456
+  });
+
+  expect(
+    await deleteComment(octokit, repo, 456)
+  ).toBeUndefined();
+  expect(octokit.issues.deleteComment).toBeCalledWith({
+    comment_id: 456
   });
 });

--- a/__tests__/comment.test.ts
+++ b/__tests__/comment.test.ts
@@ -99,25 +99,12 @@ it("createComment", async () => {
   });
 });
 
-it("removeComment", async () => {
+it("deleteComment", async () => {
   const octokit = {
     issues: {
       deleteComment: jest.fn(() => Promise.resolve())
     }
   };
-  expect(
-    await deleteComment(octokit, repo, 456)
-  ).toBeUndefined();
-  expect(octokit.issues.deleteComment).toBeCalledWith({
-    comment_id: 456
-  });
-  expect(
-    await deleteComment(octokit, repo, 456)
-  ).toBeUndefined();
-  expect(octokit.issues.deleteComment).toBeCalledWith({
-    comment_id: 456
-  });
-
   expect(
     await deleteComment(octokit, repo, 456)
   ).toBeUndefined();

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
   append:
     description: "Indicate if new comment messages should be appended to previous comment message"
     required: false
+  replace:
+    description: "Indicate if previous comment should be removed before creating a new comment"
+    required: false
   message:
     description: "comment message"
     required: false

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
   append:
     description: "Indicate if new comment messages should be appended to previous comment message"
     required: false
-  replace:
+  recreate:
     description: "Indicate if previous comment should be removed before creating a new comment"
     required: false
   message:

--- a/lib/comment.js
+++ b/lib/comment.js
@@ -9,6 +9,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.deleteComment = exports.createComment = exports.updateComment = exports.findPreviousComment = void 0;
 function headerComment(header) {
     return `<!-- Sticky Pull Request Comment${header} -->`;
 }
@@ -26,9 +27,15 @@ function updateComment(octokit, repo, comment_id, body, header, previousBody) {
     });
 }
 exports.updateComment = updateComment;
-function createComment(octokit, repo, issue_number, body, header) {
+function createComment(octokit, repo, issue_number, body, header, previousBody) {
     return __awaiter(this, void 0, void 0, function* () {
-        yield octokit.issues.createComment(Object.assign(Object.assign({}, repo), { issue_number, body: `${headerComment(header)}\n${body}` }));
+        yield octokit.issues.createComment(Object.assign(Object.assign({}, repo), { issue_number, body: previousBody ? `${previousBody}\n${body}` : `${headerComment(header)}\n${body}` }));
     });
 }
 exports.createComment = createComment;
+function deleteComment(octokit, repo, comment_id) {
+    return __awaiter(this, void 0, void 0, function* () {
+        yield octokit.issues.deleteComment(Object.assign(Object.assign({}, repo), { comment_id }));
+    });
+}
+exports.deleteComment = deleteComment;

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,4 +1,23 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -7,13 +26,6 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
-};
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
-    result["default"] = mod;
-    return result;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(require("@actions/core"));
@@ -35,6 +47,7 @@ function run() {
             const path = core.getInput("path", { required: false });
             const header = core.getInput("header", { required: false }) || "";
             const append = core.getInput("append", { required: false }) || false;
+            const recreate = core.getInput("recreate", { required: false }) || false;
             const githubToken = core.getInput("GITHUB_TOKEN", { required: true });
             const octokit = new github_1.GitHub(githubToken);
             const previous = yield comment_1.findPreviousComment(octokit, repo, number, header);
@@ -49,11 +62,13 @@ function run() {
                 body = message;
             }
             if (previous) {
-                if (append) {
-                    yield comment_1.updateComment(octokit, repo, previous.id, body, header, previous.body);
+                const previousBody = append && previous.body;
+                if (recreate) {
+                    yield comment_1.deleteComment(octokit, repo, previous.id);
+                    yield comment_1.createComment(octokit, repo, number, body, header, previousBody);
                 }
                 else {
-                    yield comment_1.updateComment(octokit, repo, previous.id, body, header);
+                    yield comment_1.updateComment(octokit, repo, previous.id, body, header, previousBody);
                 }
             }
             else {

--- a/src/comment.ts
+++ b/src/comment.ts
@@ -17,10 +17,16 @@ export async function updateComment(octokit, repo, comment_id, body, header, pre
     body: previousBody ? `${previousBody}\n${body}` : `${headerComment(header)}\n${body}`
   });
 }
-export async function createComment(octokit, repo, issue_number, body, header) {
+export async function createComment(octokit, repo, issue_number, body, header, previousBody?) {
   await octokit.issues.createComment({
     ...repo,
     issue_number,
-    body: `${headerComment(header)}\n${body}`
+    body:  previousBody ? `${previousBody}\n${body}` : `${headerComment(header)}\n${body}`
+  });
+}
+export async function deleteComment(octokit, repo, comment_id) {
+  await octokit.issues.deleteComment({
+    ...repo,
+    comment_id,
   });
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,7 @@ async function run() {
     const path = core.getInput("path", { required: false });
     const header = core.getInput("header", { required: false }) || "";
     const append = core.getInput("append", { required: false }) || false;
-    const replace = core.getInput("replace", { required: false }) || false;
+    const recreate = core.getInput("recreate", { required: false }) || false;
     const githubToken = core.getInput("GITHUB_TOKEN", { required: true });
     const octokit = new GitHub(githubToken);
     const previous = await findPreviousComment(octokit, repo, number, header);
@@ -37,7 +37,7 @@ async function run() {
 
     if (previous) {
       const previousBody = append && previous.body;
-      if (replace) {
+      if (recreate) {
         await deleteComment(octokit, repo, previous.id);
         await createComment(octokit, repo, number, body, header, previousBody);
       } else {

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,10 +35,8 @@ async function run() {
       body = message;
     }
 
-    let previousBody;
-    if (append && previous) previousBody = previous.body;
-
     if (previous) {
+      const previousBody = append && previous.body;
       if (replace) {
         await deleteComment(octokit, repo, previous.id);
         await createComment(octokit, repo, number, body, header, previousBody);


### PR DESCRIPTION
In our pull requests having lots of comments and changes can make it hard to find the PR comment from this action.

I figured the best solution would be to add an option to replace the previous comment with a new comment instead of editing the old comment, so the comment shows up at the bottom of the PR.

Changes:

1. added the `replace` option to the action definition
1. added a `deleteComment` method to remove the previous comment if it exists
1. updated `createComment` to take the `previousBody` argument. Which is used if `replace` and `append` are both true.
1. added a basic test for `deleteComment`