### PR TITLE
Update hidden identifier comment to come last instead of first

### DIFF
--- a/__tests__/comment.test.ts
+++ b/__tests__/comment.test.ts
@@ -9,14 +9,20 @@ it("findPreviousComment", async () => {
     user: {
       login: "github-actions[bot]"
     },
-    body: "<!-- Sticky Pull Request Comment -->\nprevious message"
+    body: "previous message\n<!-- Sticky Pull Request Comment -->"
   };
   const commentWithCustomHeader = {
     user: {
       login: "github-actions[bot]"
     },
-    body: "<!-- Sticky Pull Request CommentTypeA -->\nprevious message"
+    body: "previous message\n<!-- Sticky Pull Request CommentTypeA -->"
   };
+  const headerFirstComment = {
+      user: {
+        login: "github-actions[bot]"
+      },
+      body: "<!-- Sticky Pull Request CommentLegacyComment -->\nheader first message"
+  }
   const otherComments = [
     {
       user: {
@@ -28,14 +34,14 @@ it("findPreviousComment", async () => {
       user: {
         login: "github-actions[bot]"
       },
-      body: "<!-- Sticky Pull Request CommentTypeB -->\nprevious message"
-    }
+      body: "previous message\n<!-- Sticky Pull Request CommentTypeB -->"
+    },
   ];
   const octokit = {
     issues: {
       listComments: jest.fn(() =>
         Promise.resolve({
-          data: [commentWithCustomHeader, comment, ...otherComments]
+          data: [commentWithCustomHeader, comment, headerFirstComment, ...otherComments]
         })
       )
     }
@@ -45,6 +51,7 @@ it("findPreviousComment", async () => {
   expect(await findPreviousComment(octokit, repo, 123, "TypeA")).toBe(
     commentWithCustomHeader
   );
+  expect(await findPreviousComment(octokit, repo, 123, "LegacyComment")).toBe(headerFirstComment)
   expect(octokit.issues.listComments).toBeCalledWith({ issue_number: 123 });
 });
 it("updateComment", async () => {
@@ -58,22 +65,22 @@ it("updateComment", async () => {
   ).toBeUndefined();
   expect(octokit.issues.updateComment).toBeCalledWith({
     comment_id: 456,
-    body: "<!-- Sticky Pull Request Comment -->\nhello there"
+    body: "hello there\n<!-- Sticky Pull Request Comment -->"
   });
   expect(
     await updateComment(octokit, repo, 456, "hello there", "TypeA")
   ).toBeUndefined();
   expect(octokit.issues.updateComment).toBeCalledWith({
     comment_id: 456,
-    body: "<!-- Sticky Pull Request CommentTypeA -->\nhello there"
+    body: "hello there\n<!-- Sticky Pull Request CommentTypeA -->"
   });
 
   expect(
-    await updateComment(octokit, repo, 456, "hello there", "TypeA", "<!-- Sticky Pull Request CommentTypeA -->\nhello there")
+    await updateComment(octokit, repo, 456, "hello there", "TypeA", "hello there\n<!-- Sticky Pull Request CommentTypeA -->")
   ).toBeUndefined();
   expect(octokit.issues.updateComment).toBeCalledWith({
     comment_id: 456,
-    body: "<!-- Sticky Pull Request CommentTypeA -->\nhello there\nhello there"
+    body: "hello there\nhello there\n<!-- Sticky Pull Request CommentTypeA -->"
   });
 });
 it("createComment", async () => {
@@ -87,13 +94,13 @@ it("createComment", async () => {
   ).toBeUndefined();
   expect(octokit.issues.createComment).toBeCalledWith({
     issue_number: 456,
-    body: "<!-- Sticky Pull Request Comment -->\nhello there"
+    body: "hello there\n<!-- Sticky Pull Request Comment -->"
   });
   expect(
     await createComment(octokit, repo, 456, "hello there", "TypeA")
   ).toBeUndefined();
   expect(octokit.issues.createComment).toBeCalledWith({
     issue_number: 456,
-    body: "<!-- Sticky Pull Request CommentTypeA -->\nhello there"
+    body: "hello there\n<!-- Sticky Pull Request CommentTypeA -->"
   });
 });

--- a/__tests__/comment.test.ts
+++ b/__tests__/comment.test.ts
@@ -80,7 +80,7 @@ it("updateComment", async () => {
   ).toBeUndefined();
   expect(octokit.issues.updateComment).toBeCalledWith({
     comment_id: 456,
-    body: "hello there\nhello there\n<!-- Sticky Pull Request CommentTypeA -->"
+    body: "hello there\n<!-- Sticky Pull Request CommentTypeA -->\nhello there"
   });
 });
 it("createComment", async () => {

--- a/lib/comment.js
+++ b/lib/comment.js
@@ -9,26 +9,32 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.createComment = exports.updateComment = exports.findPreviousComment = void 0;
 function headerComment(header) {
     return `<!-- Sticky Pull Request Comment${header} -->`;
+}
+function removeHeaderComment(body, header) {
+    return body.replace(`\n${header}`, '');
 }
 function findPreviousComment(octokit, repo, issue_number, header) {
     return __awaiter(this, void 0, void 0, function* () {
         const { data: comments } = yield octokit.issues.listComments(Object.assign(Object.assign({}, repo), { issue_number }));
         const h = headerComment(header);
-        return comments.find(comment => comment.body.startsWith(h));
+        return comments.find(comment => comment.body.includes(h));
     });
 }
 exports.findPreviousComment = findPreviousComment;
 function updateComment(octokit, repo, comment_id, body, header, previousBody) {
     return __awaiter(this, void 0, void 0, function* () {
-        yield octokit.issues.updateComment(Object.assign(Object.assign({}, repo), { comment_id, body: previousBody ? `${previousBody}\n${body}` : `${headerComment(header)}\n${body}` }));
+        const headerIdentifier = headerComment(header);
+        const updatedBody = previousBody ? `${removeHeaderComment(previousBody, headerIdentifier)}\n${body}` : body;
+        yield octokit.issues.updateComment(Object.assign(Object.assign({}, repo), { comment_id, body: `${updatedBody}\n${headerIdentifier}` }));
     });
 }
 exports.updateComment = updateComment;
 function createComment(octokit, repo, issue_number, body, header) {
     return __awaiter(this, void 0, void 0, function* () {
-        yield octokit.issues.createComment(Object.assign(Object.assign({}, repo), { issue_number, body: `${headerComment(header)}\n${body}` }));
+        yield octokit.issues.createComment(Object.assign(Object.assign({}, repo), { issue_number, body: `${body}\n${headerComment(header)}` }));
     });
 }
 exports.createComment = createComment;

--- a/lib/comment.js
+++ b/lib/comment.js
@@ -13,9 +13,6 @@ exports.createComment = exports.updateComment = exports.findPreviousComment = vo
 function headerComment(header) {
     return `<!-- Sticky Pull Request Comment${header} -->`;
 }
-function removeHeaderComment(body, header) {
-    return body.replace(`\n${header}`, '');
-}
 function findPreviousComment(octokit, repo, issue_number, header) {
     return __awaiter(this, void 0, void 0, function* () {
         const { data: comments } = yield octokit.issues.listComments(Object.assign(Object.assign({}, repo), { issue_number }));
@@ -26,9 +23,7 @@ function findPreviousComment(octokit, repo, issue_number, header) {
 exports.findPreviousComment = findPreviousComment;
 function updateComment(octokit, repo, comment_id, body, header, previousBody) {
     return __awaiter(this, void 0, void 0, function* () {
-        const headerIdentifier = headerComment(header);
-        const updatedBody = previousBody ? `${removeHeaderComment(previousBody, headerIdentifier)}\n${body}` : body;
-        yield octokit.issues.updateComment(Object.assign(Object.assign({}, repo), { comment_id, body: `${updatedBody}\n${headerIdentifier}` }));
+        yield octokit.issues.updateComment(Object.assign(Object.assign({}, repo), { comment_id, body: previousBody ? `${previousBody}\n${body}` : `${body}\n${headerComment(header)}` }));
     });
 }
 exports.updateComment = updateComment;

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,4 +1,23 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -7,13 +26,6 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
-};
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
-    result["default"] = mod;
-    return result;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(require("@actions/core"));

--- a/src/comment.ts
+++ b/src/comment.ts
@@ -2,25 +2,31 @@ function headerComment(header) {
   return `<!-- Sticky Pull Request Comment${header} -->`;
 }
 
+function removeHeaderComment(body, header) {
+  return body.replace(`\n${header}`, '');
+}
+
 export async function findPreviousComment(octokit, repo, issue_number, header) {
   const { data: comments } = await octokit.issues.listComments({
     ...repo,
     issue_number
   });
   const h = headerComment(header);
-  return comments.find(comment => comment.body.startsWith(h));
+  return comments.find(comment => comment.body.includes(h));
 }
 export async function updateComment(octokit, repo, comment_id, body, header, previousBody?) {
+  const headerIdentifier = headerComment(header);
+  const updatedBody = previousBody ? `${removeHeaderComment(previousBody, headerIdentifier)}\n${body}` : body;
   await octokit.issues.updateComment({
     ...repo,
     comment_id,
-    body: previousBody ? `${previousBody}\n${body}` : `${headerComment(header)}\n${body}`
+    body: `${updatedBody}\n${headerIdentifier}`
   });
 }
 export async function createComment(octokit, repo, issue_number, body, header) {
   await octokit.issues.createComment({
     ...repo,
     issue_number,
-    body: `${headerComment(header)}\n${body}`
+    body: `${body}\n${headerComment(header)}`
   });
 }

--- a/src/comment.ts
+++ b/src/comment.ts
@@ -2,10 +2,6 @@ function headerComment(header) {
   return `<!-- Sticky Pull Request Comment${header} -->`;
 }
 
-function removeHeaderComment(body, header) {
-  return body.replace(`\n${header}`, '');
-}
-
 export async function findPreviousComment(octokit, repo, issue_number, header) {
   const { data: comments } = await octokit.issues.listComments({
     ...repo,
@@ -15,12 +11,10 @@ export async function findPreviousComment(octokit, repo, issue_number, header) {
   return comments.find(comment => comment.body.includes(h));
 }
 export async function updateComment(octokit, repo, comment_id, body, header, previousBody?) {
-  const headerIdentifier = headerComment(header);
-  const updatedBody = previousBody ? `${removeHeaderComment(previousBody, headerIdentifier)}\n${body}` : body;
   await octokit.issues.updateComment({
     ...repo,
     comment_id,
-    body: `${updatedBody}\n${headerIdentifier}`
+    body: previousBody ? `${previousBody}\n${body}` : `${body}\n${headerComment(header)}`
   });
 }
 export async function createComment(octokit, repo, issue_number, body, header) {


### PR DESCRIPTION
This is pretty minor, but it came up due to the newer slack integration with Github.

Currently, the github slack integration doesn't strip comments when it sends notifications, so the hidden comment shows up as the comment message (screenshot below).

<img width="641" alt="Screenshot 2020-06-24 09 40 37" src="https://user-images.githubusercontent.com/238023/85577128-fbdf5d00-b606-11ea-927a-c7d2419f0963.png">

This updates the action to put the identifier comment at the end, while maintaining backwards compatibility with existing comments.

After this change, it still shows up, but you're at least guaranteed to see the content of the comment. With longer comments or with the `append` option it likely wouldn't show up at all.

<img width="603" alt="Screenshot 2020-06-24 10 49 55" src="https://user-images.githubusercontent.com/238023/85578972-79579d00-b608-11ea-84b8-9b1617645500.png">
