### PR TITLE
Add support for deleting previously created comments

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,8 @@ inputs:
   number:
     description: "pull request number for push event"
     required: false
+  delete: 
+    description: "delete the previously created comment"
   GITHUB_TOKEN:
     description: "set secrets.GITHUB_TOKEN here"
     required: true

--- a/lib/main.js
+++ b/lib/main.js
@@ -48,11 +48,15 @@ function run() {
             const header = core.getInput("header", { required: false }) || "";
             const append = core.getInput("append", { required: false }) || false;
             const recreate = core.getInput("recreate", { required: false }) || false;
+            const deleteOldComment = core.getInput("delete", { required: false }) || false;
             const githubToken = core.getInput("GITHUB_TOKEN", { required: true });
             const octokit = new github_1.GitHub(githubToken);
             const previous = yield comment_1.findPreviousComment(octokit, repo, number, header);
             if (!message && !path) {
                 throw { message: 'Either message or path input is required' };
+            }
+            if (deleteOldComment && recreate) {
+                throw { message: 'delete and recreate cannot be both set to true' };
             }
             let body;
             if (path) {
@@ -63,7 +67,10 @@ function run() {
             }
             if (previous) {
                 const previousBody = append && previous.body;
-                if (recreate) {
+                if (deleteOldComment) {
+                    yield comment_1.deleteComment(octokit, repo, previous.id);
+                }
+                else if (recreate) {
                     yield comment_1.deleteComment(octokit, repo, previous.id);
                     yield comment_1.createComment(octokit, repo, number, body, header, previousBody);
                 }


### PR DESCRIPTION
This pull request adds support for deleting the sticky comment that is created by this action. There is already a `recreate` option, which deletes and reposts the comment. With this new option users have the ability to completely remove the comment.  

I have a use case where I only want to show the comment if certain requirements aren't met. It provides the user with an overview of issues that need to be resolved. When the user resolves one of the issues, I update the comment using this Action. But when all the issues are resolved I want the comment to be deleted. Hence this improvement. 