### PR TITLE
Don't allow empty comment body

### DIFF
--- a/lib/comment.js
+++ b/lib/comment.js
@@ -1,4 +1,23 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -10,6 +29,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.deleteComment = exports.createComment = exports.updateComment = exports.findPreviousComment = void 0;
+const core = __importStar(require("@actions/core"));
 function headerComment(header) {
     return `<!-- Sticky Pull Request Comment${header} -->`;
 }
@@ -23,12 +43,16 @@ function findPreviousComment(octokit, repo, issue_number, header) {
 exports.findPreviousComment = findPreviousComment;
 function updateComment(octokit, repo, comment_id, body, header, previousBody) {
     return __awaiter(this, void 0, void 0, function* () {
+        if (!body && !previousBody)
+            core.warning('Comment body cannot be blank');
         yield octokit.issues.updateComment(Object.assign(Object.assign({}, repo), { comment_id, body: previousBody ? `${previousBody}\n${body}` : `${body}\n${headerComment(header)}` }));
     });
 }
 exports.updateComment = updateComment;
 function createComment(octokit, repo, issue_number, body, header, previousBody) {
     return __awaiter(this, void 0, void 0, function* () {
+        if (!body)
+            core.warning('Comment body cannot be blank');
         yield octokit.issues.createComment(Object.assign(Object.assign({}, repo), { issue_number, body: previousBody ? `${previousBody}\n${body}` : `${body}\n${headerComment(header)}` }));
     });
 }

--- a/src/comment.ts
+++ b/src/comment.ts
@@ -1,3 +1,5 @@
+import * as core from "@actions/core";
+
 function headerComment(header) {
   return `<!-- Sticky Pull Request Comment${header} -->`;
 }
@@ -11,6 +13,8 @@ export async function findPreviousComment(octokit, repo, issue_number, header) {
   return comments.find(comment => comment.body.includes(h));
 }
 export async function updateComment(octokit, repo, comment_id, body, header, previousBody?) {
+  if (!body && !previousBody) core.warning('Comment body cannot be blank');
+
   await octokit.issues.updateComment({
     ...repo,
     comment_id,
@@ -18,6 +22,8 @@ export async function updateComment(octokit, repo, comment_id, body, header, pre
   });
 }
 export async function createComment(octokit, repo, issue_number, body, header, previousBody?) {
+  if (!body) core.warning('Comment body cannot be blank');
+
   await octokit.issues.createComment({
     ...repo,
     issue_number,


### PR DESCRIPTION
👋  I use this Action in an Actions workflow where it uses an output that is provided by a previous Action. Sometimes the output of the previous Action is empty. In those cases it doesn't make a lot of sense to post an empty comment. I cannot think of a reason why someone would post an empty comment.

Also I want to make sure this Action for end-users doesn't behave much different from GitHub's API/UX functionality. GitHub doesn't allow an empty comment body:

```
{
  "message": "Validation Failed",
  "errors": [
    {
      "resource": "IssueComment",
      "code": "custom",
      "field": "body",
      "message": "body cannot be blank"
    }
  ],
  "documentation_url": "https://docs.github.com/rest/reference/issues#update-an-issue-comment"
}
```



