### PR TITLE
Ignore empty body update

### DIFF
--- a/lib/comment.js
+++ b/lib/comment.js
@@ -44,15 +44,15 @@ exports.findPreviousComment = findPreviousComment;
 function updateComment(octokit, repo, comment_id, body, header, previousBody) {
     return __awaiter(this, void 0, void 0, function* () {
         if (!body && !previousBody)
-            core.warning('Comment body cannot be blank');
+            return core.warning('Comment body cannot be blank');
         yield octokit.issues.updateComment(Object.assign(Object.assign({}, repo), { comment_id, body: previousBody ? `${previousBody}\n${body}` : `${body}\n${headerComment(header)}` }));
     });
 }
 exports.updateComment = updateComment;
 function createComment(octokit, repo, issue_number, body, header, previousBody) {
     return __awaiter(this, void 0, void 0, function* () {
-        if (!body)
-            core.warning('Comment body cannot be blank');
+        if (!body && !previousBody)
+            return core.warning('Comment body cannot be blank');
         yield octokit.issues.createComment(Object.assign(Object.assign({}, repo), { issue_number, body: previousBody ? `${previousBody}\n${body}` : `${body}\n${headerComment(header)}` }));
     });
 }

--- a/src/comment.ts
+++ b/src/comment.ts
@@ -13,7 +13,7 @@ export async function findPreviousComment(octokit, repo, issue_number, header) {
   return comments.find(comment => comment.body.includes(h));
 }
 export async function updateComment(octokit, repo, comment_id, body, header, previousBody?) {
-  if (!body && !previousBody) core.warning('Comment body cannot be blank');
+  if (!body && !previousBody) return core.warning('Comment body cannot be blank');
 
   await octokit.issues.updateComment({
     ...repo,
@@ -22,7 +22,7 @@ export async function updateComment(octokit, repo, comment_id, body, header, pre
   });
 }
 export async function createComment(octokit, repo, issue_number, body, header, previousBody?) {
-  if (!body) core.warning('Comment body cannot be blank');
+  if (!body && !previousBody) return core.warning('Comment body cannot be blank');
 
   await octokit.issues.createComment({
     ...repo,


### PR DESCRIPTION
Follow up of https://github.com/marocchino/sticky-pull-request-comment/pull/197

Improvements:
- Return `createComment` and `updateComment` method if body empty to make sure API isn't made a no empty comment is posted.
- Also check for `previousBody` argument in `updateComment` method
- Added specs + Grouped `createComment` and `updateComment` spec in describe.

@marocchino This could be considered a breaking change as previous versions of this Action did post empty comments. For the end user is it however in line with what they can expect when they post an empty comment via the GitHub API. (See #197)