### PR TITLE
Buffer to string

### DIFF
--- a/__tests__/comment.test.ts
+++ b/__tests__/comment.test.ts
@@ -100,7 +100,7 @@ describe("updateComment", () => {
 
   it("without comment body and previousbody", async() => {
     expect(
-      await updateComment(octokit, repo, 456, "", null)
+      await updateComment(octokit, repo, 456, "", "")
     ).toBeUndefined();
     expect(octokit.issues.updateComment).not.toBeCalled();
     expect(core.warning).toBeCalledWith('Comment body cannot be blank');
@@ -136,7 +136,7 @@ describe("createComment", () => {
   })
   it("without comment body and previousBody", async () => {
     expect(
-      await createComment(octokit, repo, 456, "", null)
+      await createComment(octokit, repo, 456, "", "")
     ).toBeUndefined();
     expect(octokit.issues.createComment).not.toBeCalled();
     expect(core.warning).toBeCalledWith('Comment body cannot be blank');

--- a/__tests__/comment.test.ts
+++ b/__tests__/comment.test.ts
@@ -100,7 +100,7 @@ describe("updateComment", () => {
 
   it("without comment body and previousbody", async() => {
     expect(
-      await updateComment(octokit, repo, 456, "", "")
+      await updateComment(octokit, repo, 456, "", null)
     ).toBeUndefined();
     expect(octokit.issues.updateComment).not.toBeCalled();
     expect(core.warning).toBeCalledWith('Comment body cannot be blank');
@@ -136,7 +136,7 @@ describe("createComment", () => {
   })
   it("without comment body and previousBody", async () => {
     expect(
-      await createComment(octokit, repo, 456, "", "")
+      await createComment(octokit, repo, 456, "", null)
     ).toBeUndefined();
     expect(octokit.issues.createComment).not.toBeCalled();
     expect(core.warning).toBeCalledWith('Comment body cannot be blank');

--- a/lib/main.js
+++ b/lib/main.js
@@ -60,7 +60,7 @@ function run() {
             }
             let body;
             if (path) {
-                body = fs_1.readFileSync(path);
+                body = fs_1.readFileSync(path, 'utf-8');
             }
             else {
                 body = message;

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,7 +35,7 @@ async function run() {
     let body;
 
     if (path) {
-      body = readFileSync(path);
+      body = readFileSync(path, 'utf-8');
     } else {
       body = message;
     }


### PR DESCRIPTION
[`readFileSync`](https://www.geeksforgeeks.org/node-js-fs-readfilesync-method/) returns a raw buffer if no encoding format is specified. An empty markdown file will for that reason still be truthy and be posted as a comment.

Example (`a.md` is an empty file):
<details><summary><img width="827" alt="Screenshot 2020-11-06 at 09 42 52" src="https://user-images.githubusercontent.com/24505883/98345086-776d0400-2014-11eb-8df4-e1795da94992.png"></summary>

```
> const checkIfFalsy = (value) => value ? console.log('is not falsy') : console.log('is falsy')
undefined
> test = readFileSync('./a.md')
<Buffer >
> checkIfFalsy(test)
is not falsy
undefined
> test = readFileSync('./a.md', 'utf-8')
''
> checkIfFalsy(test)
is falsy
```
</details>
