### PR TITLE
fix boolean handling

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -46,9 +46,9 @@ function run() {
             const message = core.getInput("message", { required: false });
             const path = core.getInput("path", { required: false });
             const header = core.getInput("header", { required: false }) || "";
-            const append = core.getInput("append", { required: false }) || false;
-            const recreate = core.getInput("recreate", { required: false }) || false;
-            const deleteOldComment = core.getInput("delete", { required: false }) || false;
+            const append = (core.getInput("append", { required: false }) || "false") === "true";
+            const recreate = (core.getInput("recreate", { required: false }) || "false") === "true";
+            const deleteOldComment = (core.getInput("delete", { required: false }) || "false") === "true";
             const githubToken = core.getInput("GITHUB_TOKEN", { required: true });
             const octokit = new github_1.GitHub(githubToken);
             const previous = yield comment_1.findPreviousComment(octokit, repo, number, header);

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,9 +17,9 @@ async function run() {
     const message = core.getInput("message", { required: false });
     const path = core.getInput("path", { required: false });
     const header = core.getInput("header", { required: false }) || "";
-    const append = core.getInput("append", { required: false }) || false;
-    const recreate = core.getInput("recreate", { required: false }) || false;
-    const deleteOldComment = core.getInput("delete", { required: false }) || false;
+    const append = (core.getInput("append", { required: false }) || "false") === "true";
+    const recreate = (core.getInput("recreate", { required: false }) || "false") === "true";
+    const deleteOldComment = (core.getInput("delete", { required: false }) || "false") === "true";
     const githubToken = core.getInput("GITHUB_TOKEN", { required: true });
     const octokit = new GitHub(githubToken);
     const previous = await findPreviousComment(octokit, repo, number, header);


### PR DESCRIPTION
Due to https://github.com/actions/toolkit/issues/361, there is currently no way to set a boolean flag to false. This PR fixes that by checking if the string value of each boolean is equal to `"true"`.