### PR TITLE
feat: apply GitHub token by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ This library runs with GitHub Actions. If you feel that the example grammar belo
 ```yaml
 uses: marocchino/sticky-pull-request-comment@v2
 with:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   message: |
     Release ${{ github.sha }} to <https://pr-${{ github.event.number }}.example.com>
 ```
@@ -156,7 +155,7 @@ with:
 
 ### `GITHUB_TOKEN`
 
-**Required** set secrets.GITHUB_TOKEN here
+**Optional**, typically set secrets.GITHUB_TOKEN. If not set, this will use `${{ github.token }}`.
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -27,8 +27,8 @@ inputs:
     description: "other repo name limited use on github enterprise. If not set, the current repo is used by default. Note that When you trying changing a repo, be aware that GITHUB_TOKEN should also use that repo's."
     required: false
   GITHUB_TOKEN:
-    description: "set secrets.GITHUB_TOKEN here"
-    required: true
+    description: "The GitHub access token (e.g. secrets.GITHUB_TOKEN) used to create or update the comment. This defaults to ${{ github.token }}."
+    default: '${{ github.token }}'
 runs:
   using: "node12"
   main: "dist/index.js"

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ inputs:
     description: "other repo name limited use on github enterprise. If not set, the current repo is used by default. Note that When you trying changing a repo, be aware that GITHUB_TOKEN should also use that repo's."
     required: false
   GITHUB_TOKEN:
-    description: 'The GitHub access token (e.g. secrets.GITHUB_TOKEN) used to create or update the comment. This defaults to ${{ github.token }}.'
+    description: 'The GitHub access token (e.g. secrets.GITHUB_TOKEN) used to create or update the comment. This defaults to {{ github.token }}.'
     default: '${{ github.token }}'
 runs:
   using: "node12"

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ inputs:
     description: "other repo name limited use on github enterprise. If not set, the current repo is used by default. Note that When you trying changing a repo, be aware that GITHUB_TOKEN should also use that repo's."
     required: false
   GITHUB_TOKEN:
-    description: "The GitHub access token (e.g. secrets.GITHUB_TOKEN) used to create or update the comment. This defaults to ${{ github.token }}."
+    description: 'The GitHub access token (e.g. secrets.GITHUB_TOKEN) used to create or update the comment. This defaults to ${{ github.token }}.'
     default: '${{ github.token }}'
 runs:
   using: "node12"


### PR DESCRIPTION
Dear maintainer,

Thanks for your excellent Action! To make things a little easier to use, I would propose applying a simple change to apply the default GitHub token, rather than requiring the user to specify it. This change is very similar to the one here: https://github.com/styfle/cancel-workflow-action/pull/46/files

The failing build seems to be due to a permission problem since my PR build receives a read-only token, so if you copy this change and apply it manually as a PR, things should hopefully work :crossed_fingers: 