### PR TITLE
docs: updated docs with new way of saving output

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ test:
       OUTPUT="${OUTPUT//'%'/'%25'}​【7,6 m】"
       OUTPUT="${OUTPUT//$'\n'/'%0A'}"
       OUTPUT="${OUTPUT//$'\r'/'%0D'}"
-      echo "::set-output name=result::$OUTPUT"
+      echo "result=$OUTPUT" >> $GITHUB_OUTPUT
   - uses: marocchino/sticky-pull-request-comment@v2
     with:
       header: test
@@ -58,7 +58,7 @@ test:
       OUTPUT="${OUTPUT//'%'/'%25'}​【7,6 m】"
       OUTPUT="${OUTPUT//$'\n'/'%0A'}"
       OUTPUT="${OUTPUT//$'\r'/'%0D'}"
-      echo "::set-output name=result::$OUTPUT"
+      echo "result=$OUTPUT" >> $GITHUB_OUTPUT
   - uses: marocchino/sticky-pull-request-comment@v2
     with:
       append: true


### PR DESCRIPTION
Hi @marocchino, big fan of the Action you made :). I noticed a small warning message in one of our builds letting us know that `::set-output` will be deprecated soon and I figured I'd give a hand updating the readme with the new way of doing that :)

![image](https://user-images.githubusercontent.com/9394141/198229934-95ef11e8-b546-4744-84f3-2175395dbcba.png)

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/