### PR TITLE
Add option to skip updating or recreating comments when message is unchanged

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,10 @@ For more detailed information about permissions, you can read from the link belo
 
 **Optional** By default this is `false`. If set to `true`, no comment will be posted if the comment body is empty. Note that enabling this will prevent comment hiding & deletion from working when the body is empty.
 
+### `skip_unchanged`
+
+**Optional** By default this is `false`. If set to `true`, recreating or updating a comment will be skipped if the new message is identical to the current message.
+
 ### `GITHUB_TOKEN`
 
 **Optional**, You can set [PAT](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) here. If not set, this will use `${{ github.token }}`.

--- a/__tests__/comment.test.ts
+++ b/__tests__/comment.test.ts
@@ -7,7 +7,8 @@ import {
   findPreviousComment,
   getBodyOf,
   updateComment,
-  minimizeComment
+  minimizeComment,
+  commentsEqual
 } from "../src/comment"
 
 jest.mock("@actions/core", () => ({
@@ -249,4 +250,17 @@ describe("getBodyOf", () => {
       expect(getBodyOf(previous, append, hideDetails)).toEqual(expected)
     }
   )
+})
+
+describe("commentsEqual", () => {
+  test.each([
+    { body: "body", previous: "body\n<!-- Sticky Pull Request Commentheader -->", header: "header", expected: true },
+    { body: "body", previous: "body\n<!-- Sticky Pull Request Comment -->", header: "", expected: true },
+    { body: "body", previous: "body\n<!-- Sticky Pull Request Commenta different header -->", header: "header", expected: false },
+    { body: "body", previous: "body", header: "header", expected: false },
+    { body: "body", previous: "", header: "header", expected: false },
+    { body: "", previous: "body", header: "header", expected: false },
+  ])("commentsEqual(%s, %s, %s)", ({body, previous, header, expected}) => {
+    expect(commentsEqual(body, previous, header)).toEqual(expected)
+  })
 })

--- a/__tests__/config.test.ts
+++ b/__tests__/config.test.ts
@@ -12,6 +12,7 @@ beforeEach(() => {
   process.env["INPUT_HIDE_DETAILS"] = "false"
   process.env["INPUT_GITHUB_TOKEN"] = "some-token"
   process.env["INPUT_IGNORE_EMPTY"] = "false"
+  process.env["INPUT_SKIP_UNCHANGED"] = "false"
   process.env["INPUT_FOLLOW_SYMBOLIC_LINKS"] = "false"
 })
 
@@ -35,6 +36,7 @@ afterEach(() => {
   delete process.env["INPUT_GITHUB_TOKEN"]
   delete process.env["INPUT_PATH"]
   delete process.env["INPUT_IGNORE_EMPTY"]
+  delete process.env["INPUT_SKIP_UNCHANGED"]
   delete process.env["INPUT_FOLLOW_SYMBOLIC_LINKS"]
 })
 
@@ -53,7 +55,8 @@ test("repo", async () => {
     hideClassify: "OUTDATED",
     hideDetails: false,
     githubToken: "some-token",
-    ignoreEmpty: false
+    ignoreEmpty: false,
+    skipUnchanged: false
   })
   expect(await require("../src/config").getBody()).toEqual("")
 })
@@ -71,7 +74,8 @@ test("header", async () => {
     hideClassify: "OUTDATED",
     hideDetails: false,
     githubToken: "some-token",
-    ignoreEmpty: false
+    ignoreEmpty: false,
+    skipUnchanged: false
   })
   expect(await require("../src/config").getBody()).toEqual("")
 })
@@ -89,7 +93,8 @@ test("append", async () => {
     hideClassify: "OUTDATED",
     hideDetails: false,
     githubToken: "some-token",
-    ignoreEmpty: false
+    ignoreEmpty: false,
+    skipUnchanged: false
   })
   expect(await require("../src/config").getBody()).toEqual("")
 })
@@ -107,7 +112,8 @@ test("recreate", async () => {
     hideClassify: "OUTDATED",
     hideDetails: false,
     githubToken: "some-token",
-    ignoreEmpty: false
+    ignoreEmpty: false,
+    skipUnchanged: false
   })
   expect(await require("../src/config").getBody()).toEqual("")
 })
@@ -125,7 +131,8 @@ test("delete", async () => {
     hideClassify: "OUTDATED",
     hideDetails: false,
     githubToken: "some-token",
-    ignoreEmpty: false
+    ignoreEmpty: false,
+    skipUnchanged: false
   })
   expect(await require("../src/config").getBody()).toEqual("")
 })
@@ -143,7 +150,8 @@ test("hideOldComment", async () => {
     hideClassify: "OUTDATED",
     hideDetails: false,
     githubToken: "some-token",
-    ignoreEmpty: false
+    ignoreEmpty: false,
+    skipUnchanged: false
   })
   expect(await require("../src/config").getBody()).toEqual("")
 })
@@ -161,7 +169,8 @@ test("hideAndRecreate", async () => {
     hideClassify: "OUTDATED",
     hideDetails: false,
     githubToken: "some-token",
-    ignoreEmpty: false
+    ignoreEmpty: false,
+    skipUnchanged: false
   })
   expect(await require("../src/config").getBody()).toEqual("")
 })
@@ -179,7 +188,8 @@ test("hideClassify", async () => {
     hideClassify: "OFF_TOPIC",
     hideDetails: false,
     githubToken: "some-token",
-    ignoreEmpty: false
+    ignoreEmpty: false,
+    skipUnchanged: false
   })
   expect(await require("../src/config").getBody()).toEqual("")
 })
@@ -197,7 +207,8 @@ test("hideDetails", async () => {
     hideClassify: "OUTDATED",
     hideDetails: true,
     githubToken: "some-token",
-    ignoreEmpty: false
+    ignoreEmpty: false,
+    skipUnchanged: false
   })
   expect(await require("../src/config").getBody()).toEqual("")
 })
@@ -216,7 +227,8 @@ describe("path", () => {
       hideClassify: "OUTDATED",
       hideDetails: false,
       githubToken: "some-token",
-      ignoreEmpty: false
+      ignoreEmpty: false,
+      skipUnchanged: false
     })
     expect(await require("../src/config").getBody()).toEqual("hi there\n")
   })
@@ -235,7 +247,8 @@ describe("path", () => {
       hideClassify: "OUTDATED",
       hideDetails: false,
       githubToken: "some-token",
-      ignoreEmpty: false
+      ignoreEmpty: false,
+      skipUnchanged: false
     })
     expect(await require("../src/config").getBody()).toEqual(
       "hi there\n\nhey there\n"
@@ -256,7 +269,8 @@ describe("path", () => {
       hideClassify: "OUTDATED",
       hideDetails: false,
       githubToken: "some-token",
-      ignoreEmpty: false
+      ignoreEmpty: false,
+      skipUnchanged: false
     })
     expect(await require("../src/config").getBody()).toEqual("")
   })
@@ -276,7 +290,8 @@ test("message", async () => {
     hideClassify: "OUTDATED",
     hideDetails: false,
     githubToken: "some-token",
-    ignoreEmpty: false
+    ignoreEmpty: false,
+    skipUnchanged: false
   })
   expect(await require("../src/config").getBody()).toEqual("hello there")
 })
@@ -295,7 +310,28 @@ test("ignore_empty", async () => {
     hideClassify: "OUTDATED",
     hideDetails: false,
     githubToken: "some-token",
-    ignoreEmpty: true
+    ignoreEmpty: true,
+    skipUnchanged: false
+  })
+  expect(await require("../src/config").getBody()).toEqual("")
+})
+
+test("skip_unchanged", async () => {
+  process.env["INPUT_SKIP_UNCHANGED"] = "true"
+  expect(require("../src/config")).toMatchObject({
+    pullRequestNumber: expect.any(Number),
+    repo: {owner: "marocchino", repo: "stick-pull-request-comment"},
+    header: "",
+    append: false,
+    recreate: false,
+    deleteOldComment: false,
+    hideOldComment: false,
+    hideAndRecreate: false,
+    hideClassify: "OUTDATED",
+    hideDetails: false,
+    githubToken: "some-token",
+    ignoreEmpty: false,
+    skipUnchanged: true
   })
   expect(await require("../src/config").getBody()).toEqual("")
 })

--- a/action.yml
+++ b/action.yml
@@ -61,6 +61,10 @@ inputs:
     description: "Indicates whether to ignore missing or empty messages"
     default: "false"
     required: false
+  skip_unchanged:
+    description: "only update or recreate if message is different from previous. Only `true` is allowed. Just skip this item when you don't need it."
+    default: "false"
+    required: false
   follow_symbolic_links:
     description: "Indicates whether to follow symbolic links for path"
     default: "false"

--- a/src/comment.ts
+++ b/src/comment.ts
@@ -15,6 +15,10 @@ function headerComment(header: String): string {
   return `<!-- Sticky Pull Request Comment${header} -->`
 }
 
+function bodyWithHeader(body: string, header: string): string {
+  return `${body}\n${headerComment(header)}`
+}
+
 export async function findPreviousComment(
   octokit: InstanceType<typeof GitHub>,
   repo: {
@@ -100,7 +104,7 @@ export async function updateComment(
         id,
         body: previousBody
           ? `${previousBody}\n${body}`
-          : `${body}\n${headerComment(header)}`
+          : bodyWithHeader(body, header)
       }
     }
   )
@@ -126,7 +130,7 @@ export async function createComment(
     issue_number,
     body: previousBody
       ? `${previousBody}\n${body}`
-      : `${body}\n${headerComment(header)}`
+      : bodyWithHeader(body, header)
   })
 }
 export async function deleteComment(
@@ -162,7 +166,7 @@ export async function minimizeComment(
 }
 
 export function getBodyOf(
-  previous: {body?: string},
+  previous: {body: string},
   append: boolean,
   hideDetails: boolean
 ): string | undefined {
@@ -175,4 +179,13 @@ export function getBodyOf(
   }
 
   return previous.body?.replace(/(<details.*?)\s*\bopen\b(.*>)/g, "$1$2")
+}
+
+export function commentsEqual(
+  body: string,
+  previous: string,
+  header: string
+): boolean {
+  const newBody = bodyWithHeader(body, header)
+  return newBody === previous
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -28,6 +28,9 @@ export const onlyCreateComment = core.getBooleanInput("only_create", {
 export const onlyUpdateComment = core.getBooleanInput("only_update", {
   required: true
 })
+export const skipUnchanged = core.getBooleanInput("skip_unchanged", {
+  required: true
+})
 export const hideOldComment = core.getBooleanInput("hide", {required: true})
 export const githubToken = core.getInput("GITHUB_TOKEN", {required: true})
 export const ignoreEmpty = core.getBooleanInput("ignore_empty", {

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,7 @@ import {
   recreate,
   repo,
   ignoreEmpty,
+  skipUnchanged,
   onlyCreateComment,
   onlyUpdateComment
 } from "./config"
@@ -23,7 +24,8 @@ import {
   findPreviousComment,
   getBodyOf,
   minimizeComment,
-  updateComment
+  updateComment,
+  commentsEqual
 } from "./comment"
 
 async function run(): Promise<undefined> {
@@ -96,6 +98,11 @@ async function run(): Promise<undefined> {
 
     if (hideOldComment) {
       await minimizeComment(octokit, previous.id, hideClassify)
+      return
+    }
+
+    if (skipUnchanged && commentsEqual(body, previous.body, header)) {
+      // don't recreate or update if the message is unchanged
       return
     }
 


### PR DESCRIPTION
To avoid repeatedly posting the same message, I've adding an option to compare the new and previous message and skip hide_and_recreate, recreate and update steps if they are the same.