### PR TITLE
Place comment identifier at top

### DIFF
--- a/src/comment.ts
+++ b/src/comment.ts
@@ -16,7 +16,7 @@ function headerComment(header: String): string {
 }
 
 function bodyWithHeader(body: string, header: string): string {
-  return `${body}\n${headerComment(header)}`
+  return `${headerComment(header)}\n{body}`
 }
 
 export async function findPreviousComment(


### PR DESCRIPTION
Resolves #1362

Place the comment identifier at the top to keep it from interrupting markdown structures built by appending to the comment, such as tables, which fail with a comment in the middle of them.