### PR TITLE
Fix test action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ jobs:
           EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
           echo "all_result<<$EOF" >> "$GITHUB_ENV"
           yarn all >> "$GITHUB_ENV"
+          echo >> "$GITHUB_ENV"  # yarn all doesn't necessarily produce a newline
           echo "$EOF" >> "$GITHUB_ENV"
         id: all
       - uses: ./


### PR DESCRIPTION
`yarn all` doesn't necessarily add a newline at the end of its output. The env reader expects the EOF string to be on its own line, so if the yarn command does not produce this, the workflow fails.