### PR TITLE
Don't create a comment if hide: true

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -71,7 +71,7 @@ async function run(): Promise<undefined> {
     }
     
     if (hideOldComment) {
-      if (!previous) {
+      if (previous) {
         await minimizeComment(octokit, previous.id, hideClassify)
       }
       return


### PR DESCRIPTION
Fixing https://github.com/marocchino/sticky-pull-request-comment/issues/1082

If you set `hide: true`, I don't think the intention would ever be to create a new unhidden comment. This changes the behavior to be inline with deleting: don't do anything if `hide: true` and there's no previous comment.